### PR TITLE
Downgraded to Bun v1.2.2

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Images
+name: Build and Push Test Docker Images
 
 on:
   push:

--- a/dockerfile
+++ b/dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update && apt-get install -y \
   libxshmfence1 \
   && rm -rf /var/lib/apt/lists/*
 
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+&& apt-get install -y nodejs
+
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 WORKDIR /app

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:debian
+FROM oven/bun:1.2.2-debian
 
 RUN apt-get update && apt-get install -y \
   chromium \

--- a/dockerfile
+++ b/dockerfile
@@ -1,22 +1,22 @@
 FROM oven/bun:1.2.2-debian
 
 RUN apt-get update && apt-get install -y \
-  chromium \
-  libnss3 \
-  libatk1.0-0 \
-  libatk-bridge2.0-0 \
-  libcups2 \
-  libxcomposite1 \
-  libxdamage1 \
-  libxrandr2 \
-  libgbm1 \
-  libasound2 \
-  libxshmfence1 \
-  && rm -rf /var/lib/apt/lists/*
-
+    curl \
+    chromium \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libxshmfence1 \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-&& apt-get install -y nodejs
+ && apt-get install -y nodejs
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 

--- a/dockerfile
+++ b/dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     libxshmfence1 \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
  && apt-get install -y nodejs
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium


### PR DESCRIPTION
This pull request includes changes to the Docker workflow and Dockerfile to improve the build process and update dependencies. The most important changes include renaming the workflow for clarity, updating the base image version, and adding new dependencies.

**Docker workflow improvements:**

* [`.github/workflows/docker-test.yml`](diffhunk://#diff-baa08c0b7cb0ae6357ecf7ecaa2d7aff0bfa417e10e1ec6fbc29232cb0166da7L1-R1): Renamed the workflow from "Build and Push Docker Images" to "Build and Push Test Docker Images" for better clarity.

**Dockerfile updates:**

* [`dockerfile`](diffhunk://#diff-254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacfL1-R4): Updated the base image from `oven/bun:debian` to `oven/bun:1.2.2-debian` to fix upstream bug with latest version of Bun.
* [`dockerfile`](diffhunk://#diff-254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacfL1-R4): Added `curl` as a new dependency to support additional installation script.
* [`dockerfile`](diffhunk://#diff-254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacfR18-R20): Added a new `RUN` command to install Node.js by using the NodeSource setup script, ensuring the availability of the latest Node.js version with type stripping for email flow.